### PR TITLE
Memoize session

### DIFF
--- a/app/jobs/regular/sync_backups_to_drive.rb
+++ b/app/jobs/regular/sync_backups_to_drive.rb
@@ -4,9 +4,7 @@ module Jobs
     sidekiq_options queue: 'low'
 
     def execute(arg)
-      Backup.all.take(SiteSetting.discourse_backups_quantity).each {|backup| DiscourseBackupToDrive::DriveSynchronizer.new(backup).sync }
+      Backup.all.take(SiteSetting.discourse_backups_drive_quantity).each {|backup| DiscourseBackupToDrive::DriveSynchronizer.new(backup).sync }
     end
   end
 end
-
-

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,5 +1,5 @@
 en:
   site_settings:
-    discourse_backups_to_drive_enabled: "Enable the drive backups plugin. After enabling this, it will work on your next backup"
-    discourse_backups_to_drive_quantity: "How many backups will be kept in Google Drive"
-    discourse_backups_to_drive_api_key: "Your Drive Generated Access Token"
+    discourse_backups_drive_enabled: "Enable the drive backups plugin. After enabling this, it will work on your next backup"
+    discourse_backups_drive_quantity: "How many backups will be kept in Google Drive"
+    discourse_backups_drive_api_key: "Your Drive Generated Access Token"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 plugins:
-  discourse_backups_enabled:
+  discourse_backups_drive_enabled:
     default: false
-  discourse_backups_quantity:
+  discourse_backups_drive_quantity:
     default: 5
-  discourse_backups_api_key:
+  discourse_backups_drive_api_key:
     default: ''

--- a/lib/drive_synchronizer.rb
+++ b/lib/drive_synchronizer.rb
@@ -3,16 +3,14 @@ module DiscourseBackupToDrive
 
     def initialize(backup)
       super(backup)
-      @api_key = SiteSetting.discourse_backups_api_key
-      @turned_on = SiteSetting.discourse_backups_enabled
-      @number_of_backups = SiteSetting.discourse_backups_quantity
+      @api_key = SiteSetting.discourse_backups_drive_api_key
+      @turned_on = SiteSetting.discourse_backups_drive_enabled
       @session = GoogleDrive::Session.from_service_account_key(StringIO.new(@api_key))
     end
 
     def can_sync?
       @turned_on && @api_key.present? && backup.present?
     end
-
 
     protected
     def perform_sync
@@ -33,5 +31,6 @@ module DiscourseBackupToDrive
         folder.add(file)
       end
     end
+    
   end
 end

--- a/lib/drive_synchronizer.rb
+++ b/lib/drive_synchronizer.rb
@@ -5,7 +5,11 @@ module DiscourseBackupToDrive
       super(backup)
       @api_key = SiteSetting.discourse_backups_drive_api_key
       @turned_on = SiteSetting.discourse_backups_drive_enabled
-      @session = GoogleDrive::Session.from_service_account_key(StringIO.new(@api_key))
+      # @session = GoogleDrive::Session.from_service_account_key(StringIO.new(@api_key))
+    end
+
+    def session
+      @session ||= GoogleDrive::Session.from_service_account_key(StringIO.new(@api_key))
     end
 
     def can_sync?
@@ -14,11 +18,13 @@ module DiscourseBackupToDrive
 
     protected
     def perform_sync
+      session = session
+      drive_sess = session
       full_path = backup.path
       filename = backup.filename
-      file = @session.upload_from_file(full_path, filename)
-      add_to_folder(@session, file)
-      @session.root_collection.remove(file)
+      file = drive_sess.upload_from_file(full_path, filename)
+      add_to_folder(drive_sess, file)
+      ssession.root_collection.remove(file)
     end
 
     def add_to_folder(session, file)
@@ -31,6 +37,6 @@ module DiscourseBackupToDrive
         folder.add(file)
       end
     end
-    
+
   end
 end

--- a/lib/drive_synchronizer.rb
+++ b/lib/drive_synchronizer.rb
@@ -5,7 +5,6 @@ module DiscourseBackupToDrive
       super(backup)
       @api_key = SiteSetting.discourse_backups_drive_api_key
       @turned_on = SiteSetting.discourse_backups_drive_enabled
-      # @session = GoogleDrive::Session.from_service_account_key(StringIO.new(@api_key))
     end
 
     def session
@@ -18,15 +17,14 @@ module DiscourseBackupToDrive
 
     protected
     def perform_sync
-      session = session
       full_path = backup.path
       filename = backup.filename
-      file = drive_sess.upload_from_file(full_path, filename)
-      add_to_folder(drive_sess, file)
-      ssession.root_collection.remove(file)
+      file = session.upload_from_file(full_path, filename)
+      add_to_folder(file)
+      session.root_collection.remove(file)
     end
 
-    def add_to_folder(session, file)
+    def add_to_folder(file)
       folder_name = Discourse.current_hostname
       folder = session.collection_by_title(folder_name)
       if folder.present?

--- a/lib/drive_synchronizer.rb
+++ b/lib/drive_synchronizer.rb
@@ -19,7 +19,6 @@ module DiscourseBackupToDrive
     protected
     def perform_sync
       session = session
-      drive_sess = session
       full_path = backup.path
       filename = backup.filename
       file = drive_sess.upload_from_file(full_path, filename)

--- a/plugin.rb
+++ b/plugin.rb
@@ -22,10 +22,10 @@ gem 'google-api-client', "0.10.3", { require: false }
 gem 'google_drive', '2.1.2'
 require 'sidekiq'
 
-enabled_site_setting :discourse_backups_enabled
+enabled_site_setting :discourse_backups_drive_enabled
 
 after_initialize do
-	load File.expand_path("../lib/synchronizer.rb", __FILE__)
+  load File.expand_path("../lib/synchronizer.rb", __FILE__)
   load File.expand_path("../app/jobs/regular/sync_backups_to_drive.rb", __FILE__)
   load File.expand_path("../lib/drive_synchronizer.rb", __FILE__)
 

--- a/spec/drive_synchronizer_spec.rb
+++ b/spec/drive_synchronizer_spec.rb
@@ -12,29 +12,29 @@ describe ::DiscourseBackupToDrive::DriveSynchronizer do
 
   describe "#can_sync?" do
     it "should return false when disabled via site setting" do
-      SiteSetting.discourse_backups_enabled = false
-      SiteSetting.discourse_backups_api_key = 'test_key'
+      SiteSetting.discourse_backups_drive_enabled = false
+      SiteSetting.discourse_backups_drive_api_key = 'test_key'
       ds = described_class.new(backup)
       expect(ds.can_sync?).to eq(false)
     end
 
     it "should return false when the backup is missing" do
-      SiteSetting.discourse_backups_enabled = true
-      SiteSetting.discourse_backups_api_key = 'test_key'
+      SiteSetting.discourse_backups_drive_enabled = true
+      SiteSetting.discourse_backups_drive_api_key = 'test_key'
       ds = described_class.new(nil)
       expect(ds.can_sync?).to eq(false)
     end
 
     it "should return false when the api key is missing" do
-      SiteSetting.discourse_backups_enabled = true
-      SiteSetting.discourse_backups_api_key = ''
+      SiteSetting.discourse_backups_drive_enabled = true
+      SiteSetting.discourse_backups_drive_api_key = ''
       ds = described_class.new(backup)
       expect(ds.can_sync?).to eq(false)
     end
 
     it "should return true when everything is correct" do
-      SiteSetting.discourse_backups_enabled = true
-      SiteSetting.discourse_backups_api_key = 'test_key'
+      SiteSetting.discourse_backups_drive_enabled = true
+      SiteSetting.discourse_backups_drive_api_key = 'test_key'
       ds = described_class.new(backup)
       expect(ds.can_sync?).to eq(true)
     end


### PR DESCRIPTION
Memoize session
Deleted the session argument in `add_to_folder(session, file)`
session it's a method now and we can call it directly within `add_to_folder()` to return @session
