### PR TITLE
added delete method

### DIFF
--- a/lib/drive_synchronizer.rb
+++ b/lib/drive_synchronizer.rb
@@ -35,5 +35,16 @@ module DiscourseBackupToDrive
       end
     end
 
+    def remove_old_files
+      folder_name = Discourse.current_hostname
+      google_files = session.collection_by_title(folder_name).files
+      sorted = google_files.sort_by {|x| x.created_time}
+      keep = sorted.take(SiteSetting.discourse_sync_to_googledrive_quantity)
+      trash = (google_files - keep).map(&:name)
+      trash.each do |f|
+        session.collection_by_title(folder_name).file_by_title(f).delete(permanent = true)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Hi Kaja,

since you posted in stackoverflow, I would just give a try to the delete method.

I'll explain what I've done with it:

```
def remove_old_files
  google_files = session.files
  sorted = google_files.sort_by {|x| x.created_time}
  keep = sorted.take(SiteSetting.discourse_sync_to_googledrive_quantity)
  trash = google_files - keep
  trash.each { |d| d.delete(true) }
end
```

I've changed  `google_files = session.files` into `google_files = session.collection_by_title(folder_name)`.files because we want to only compare with the files located in the discourse folder, and not with all the files in the service account. There are some extra files in the root folder that have nothing to do with discourse, and that breaks the calculation of `keep = sorted.take(SiteSetting.discourse_sync_to_googledrive_quantity)`

I've added `(&:map)` to take the objects by its name because we were sending **objects** to compare in google drive, and Google Drive was complaining in the method `.file_by_title(f)` because it was expecting **strings to compare**.

As I said in the chat, I chained instance methods from google drive to access the stuff inside discourse folder:

```session.collection_by_title(folder_name).file_by_title(f).delete(permanent = true)```

```session``` accesses google drive. ```.collection_by_title(folder_name)``` looks for the folder. ```.file_by_title(f)``` compares each file we send to the titles of the files inside discourse folder. ```.delete``` deletes the files.