### PR TITLE
update drive_synchronizer.rb

### DIFF
--- a/lib/drive_synchronizer.rb
+++ b/lib/drive_synchronizer.rb
@@ -5,11 +5,10 @@ module DiscourseBackupToDrive
       super(backup)
       @api_key = SiteSetting.discourse_sync_to_googledrive_api_key
       @turned_on = SiteSetting.discourse_sync_to_googledrive_enabled
-      @folder_name = Discourse.current_hostname
     end
 
     def session
-      @session ||= GoogleDrive::Session.from_config("config.json")
+      @session ||= GoogleDrive::Session.from_service_account_key(StringIO.new(@api_key))
     end
 
     def can_sync?


### PR DESCRIPTION
bringing back .from_service_account_key(StringIO.new(@api_key))
deleted the variable @folder_name because we don't use it - if you want to work to refactor the folder_name let's please look into this together when I'm in the office. I've already tried yesterday and it was breaking the app. I think it's better if we memoize it (even tho, that was also breaking the app). Let's leave the code as it is for @eviltrout to check it and get some feedback from him.