### PR TITLE
save in backups folder

### DIFF
--- a/lib/drive_downloader.rb
+++ b/lib/drive_downloader.rb
@@ -38,11 +38,13 @@ module DiscourseDownloadFromDrive
       # returns file_id
     end
 
-    def create_url
-      folder_name = Discourse.current_hostname
+    def create_from_id(file_id)
       found = google_files.select { |f| f.id == file_id }
       file_title = found.first.title
-      file_url = session.collection_by_title(folder_name).file_by_title(file_title).human_url
+      file = session.file_by_title(file_title)
+      path = File.join(Backup.base_directory, file_title)
+      file.download_to_file("#{path}")
     end
+
   end
 end


### PR DESCRIPTION
Hey Kaja,
@eviltrout said:
> the job will have to download the file, and once it's downloaded send a URL to the downloaded file
> I think this is similar to what discourse does now - the email contains a public link
> so if you download it to that same directory it should be accessible

This PR covers the last line, "**download it to that same directory**".

What I've done:
! important: The backups that Discourse generates are stored here: `discourse/public/backups/default` 
If you go to that folder, you'll see a bunch of backups! I've found out this playing with the `self.base_directory` from `Backup.rb`.

This method downloads the file from Google Drive to that directory. 
I'll continue working on this.