### PR TITLE
controller/index

### DIFF
--- a/app/controllers/downloaders_controller.rb
+++ b/app/controllers/downloaders_controller.rb
@@ -4,7 +4,7 @@ class DownloadersController < ApplicationController
   skip_before_filter :check_xhr
   # skip_before_filter :verify_authenticity_token, :if => Proc.new { |c| c.request.format == 'application/json' }
 
-  def show
+  def index
     google_list = DiscourseDownloadFromDrive::DriveDownloader.new(nil).json_list
 
     respond_to do |format|

--- a/plugin.rb
+++ b/plugin.rb
@@ -38,7 +38,7 @@ after_initialize do
   end
 
   Discourse::Application.routes.append do
-    get "/admin/plugins/discourse-sync-to-googledrive/downloader" => "downloaders#show"
+    get "/admin/plugins/discourse-sync-to-googledrive/downloader" => "downloaders#index"
     post "/admin/plugins/discourse-sync-to-googledrive/downloader", to: "downloaders#create", as: "download_file"
   end
 

--- a/spec/downloaders_controller_spec.rb
+++ b/spec/downloaders_controller_spec.rb
@@ -6,7 +6,7 @@ describe ApplicationController::DownloadersController, type: :controller do
     expect(DownloadersController < ApplicationController).to eq(true)
   end
 
-  describe "GET #show" do
+  describe "GET #index" do
     let(:sample_json) {
       "{\"files\":[
           {
@@ -25,12 +25,12 @@ describe ApplicationController::DownloadersController, type: :controller do
     }
 
     it "returns a json list of all google_drive files" do
-      xhr :get, :show, format: :json
+      xhr :get, :index, format: :json
       expect(response.body).to eq(sample_json)
     end
 
     it "responds with 200 status" do
-      xhr :get, :show
+      xhr :get, :index
       expect(response).to be_success
       expect(response).to have_http_status(200)
     end
@@ -58,6 +58,6 @@ describe ApplicationController::DownloadersController, type: :controller do
       expect(response).to be_success
       expect(response).to have_http_status(200)
     end
-    
+
   end
 end


### PR DESCRIPTION
Hi Kaja,

I leave this PR open for you to think about it. If you agree then go ahead and merge. 

Our current show action is listing all the files, usually the behavior of index. Looking at backups_controller.rb in Discourse, index renders the json files, basically what we are doing too.
As we have to build the controller kind of in analogy to the backups_controller.rb from Discourse, it's easier to follow their naming and imitate (we will also have to build a show and email actions).
