### PR TITLE
download feature

### DIFF
--- a/app/controllers/downloaders_controller.rb
+++ b/app/controllers/downloaders_controller.rb
@@ -8,44 +8,22 @@ class DownloadersController < Admin::AdminController
     render json: google_list
   end
 
-  # def create
-  #   file_id = params.fetch(:file_id)
-  #   #file_id = "0Byyflt8z3jarbm5DZGNNVXZSWjg"
-  #   file_path = DiscourseDownloadFromDrive::DriveDownloader.new(file_id).download
-  #   @backup = File.open(file_path)
-  #   # puts @backup
-  #   # puts @backup.path
-  #   Rails.logger.debug(">>>>>>>>>>>>>>>>>>> @BACKUP >>>>>>>>>>>: #{@backup}")
-  # end
-
   def email
-    # @file_id = DiscourseDownloadFromDrive::DriveDownloader[params.fetch(:file_id)]
-    #   token = EmailBackupToken.set(current_user.id)
     download_url = "#{url_for(controller: 'downloaders', action: 'show')}"
     Jobs.enqueue(:download_drive_email, to_address: 'example@email.com', drive_url: download_url)
     render nothing: true
-    #   render nothing: true
-    # else
-    #   render nothing: true, status: 404
-    # end
   end
 
   def show
     file_id = params.fetch(:file_id)
     file_path = DiscourseDownloadFromDrive::DriveDownloader.new(file_id).download
-    #backup = File.open(file_path)
+    @backup = File.open(file_path)
     if @error
       render layout: 'no_ember', status: 422
     else
       render nothing: true, status: 404
     end
-    # # puts  params.fetch(:file_id)
-    # Rails.logger.debug(">>>>>>>>>>>>>>>>>>> PARAMS >>>>>>>>>>>>>>>>>>: #{params.fetch(:file_id).inspect}")
-    # # "0Byyflt8z3jarbm5DZGNNVXZSWjg"
-    # Rails.logger.debug(">>>>>>>>>>>>>>>>>>> @BACKUP >>>>>>>>>>>: #{@backup.inspect}")
-    # Rails.logger.debug(">>>>>>>>>>>>>>>>>>> @BACKUP.PATH >>>>>>>>>>>: #{@backup.path}")
-    #
-    # render plain: 'hello, I am render plain!'
+
   end
 
 end

--- a/app/controllers/downloaders_controller.rb
+++ b/app/controllers/downloaders_controller.rb
@@ -8,9 +8,44 @@ class DownloadersController < Admin::AdminController
     render json: google_list
   end
 
-  def create
-    @file_id = params[:file_id]
-    Jobs.enqueue(:send_download_drive_link, file_id: @file_id)
-    render json: { file_id: @file_id }
+  # def create
+  #   file_id = params.fetch(:file_id)
+  #   #file_id = "0Byyflt8z3jarbm5DZGNNVXZSWjg"
+  #   file_path = DiscourseDownloadFromDrive::DriveDownloader.new(file_id).download
+  #   @backup = File.open(file_path)
+  #   # puts @backup
+  #   # puts @backup.path
+  #   Rails.logger.debug(">>>>>>>>>>>>>>>>>>> @BACKUP >>>>>>>>>>>: #{@backup}")
+  # end
+
+  def email
+    # @file_id = DiscourseDownloadFromDrive::DriveDownloader[params.fetch(:file_id)]
+    #   token = EmailBackupToken.set(current_user.id)
+    download_url = "#{url_for(controller: 'downloaders', action: 'show')}"
+    Jobs.enqueue(:download_drive_email, to_address: 'example@email.com', drive_url: download_url)
+    render nothing: true
+    #   render nothing: true
+    # else
+    #   render nothing: true, status: 404
+    # end
   end
+
+  def show
+    file_id = params.fetch(:file_id)
+    file_path = DiscourseDownloadFromDrive::DriveDownloader.new(file_id).download
+    #backup = File.open(file_path)
+    if @error
+      render layout: 'no_ember', status: 422
+    else
+      render nothing: true, status: 404
+    end
+    # # puts  params.fetch(:file_id)
+    # Rails.logger.debug(">>>>>>>>>>>>>>>>>>> PARAMS >>>>>>>>>>>>>>>>>>: #{params.fetch(:file_id).inspect}")
+    # # "0Byyflt8z3jarbm5DZGNNVXZSWjg"
+    # Rails.logger.debug(">>>>>>>>>>>>>>>>>>> @BACKUP >>>>>>>>>>>: #{@backup.inspect}")
+    # Rails.logger.debug(">>>>>>>>>>>>>>>>>>> @BACKUP.PATH >>>>>>>>>>>: #{@backup.path}")
+    #
+    # render plain: 'hello, I am render plain!'
+  end
+
 end

--- a/lib/drive_downloader.rb
+++ b/lib/drive_downloader.rb
@@ -4,7 +4,7 @@ module DiscourseDownloadFromDrive
     attr_accessor :google_files, :session, :file_id
 
     def initialize(file_id)
-      @file_id = pick_file(file_id)
+      @file_id = file_id
       @api_key = SiteSetting.discourse_sync_to_googledrive_api_key
       @turned_on = SiteSetting.discourse_sync_to_googledrive_enabled
     end
@@ -29,21 +29,13 @@ module DiscourseDownloadFromDrive
       {"files" => list_files}.to_json
     end
 
-    def pick_file(file_id)
-      @file_id = "0B7WjYjWZJv_4blA0a2p6RzVraFE"
-      # click on a file from JsonFile sends a POST :file_id to create
-      # something like a <%= select_tag(:file_id) %>
-      # pick by file_id from the view
-      # google_files.file_id(picked)
-      # returns file_id
-    end
-
-    def create_from_id(file_id)
+    def download
       found = google_files.select { |f| f.id == file_id }
       file_title = found.first.title
       file = session.file_by_title(file_title)
       path = File.join(Backup.base_directory, file_title)
       file.download_to_file("#{path}")
+      path
     end
 
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -39,7 +39,11 @@ after_initialize do
 
   Discourse::Application.routes.append do
     get "/admin/plugins/discourse-sync-to-googledrive/downloader" => "downloaders#index"
-    post "/admin/plugins/discourse-sync-to-googledrive/downloader", to: "downloaders#create", as: "download_file"
+    get "/admin/plugins/discourse-sync-to-googledrive/downloader/:file_id" => "downloaders#show"
+    put "/admin/plugins/discourse-sync-to-googledrive/downloader/:file_id" => "downloaders#show"
+    put "/admin/plugins/discourse-sync-to-googledrive/downloader" => "downloaders#email"
+    # post "/admin/plugins/discourse-sync-to-googledrive/downloader" => "downloaders#create"
+    # post "/admin/plugins/discourse-sync-to-googledrive/downloader", to: "downloaders#create", as: "download_file"
   end
 
 end


### PR DESCRIPTION
Hi Kaja,

I create this PR so you can check what I've done. Clicking on the download button in the frontend triggers the download of the file and saves it in the public/backups folder. The next is triggering an email with the local url after the download is done.

* I've connected backend and frontend through the same endpoint from the ajax put in ember + rails, adding the parameter in the routes for #show.

* Modified the create_from_id method in the DriveDownloader class, it doesn't need to take any argument because we already are initialising the file_id. I also renamed it to download. The method returns `path` now, so we can work with the object doing File.open(file_path), because it was returning `nil`. We might not even need the object, and just only the path, but just in case I've created it.

* The #show is a minified version of the method so it's easier to test like this, it takes the file id from the params sent by ember. Passes it through the DriveDownloader(file_id) and executes download.

There's quite some work to be done yet:

* **Find out how to trigger the email**. This means:
- Work in the controller email method.
- Work in the Job.
* Complete the methods to verify there's an email token and check for errors etc: in analogy to discourse controller, with the EmailBackupToken. 

The path to the file is simply the url for the controller show, because it's already creating the url like blablabla.com/downloaders/1245656 : `download_url = "#{url_for(controller: 'downloaders', action: 'show')}" `. Maybe @eviltrout can give some tips on how to trigger the email?