### PR TITLE
FIX: Update dependencies; Enable plugin in spec.

### DIFF
--- a/app/controllers/downloaders_controller.rb
+++ b/app/controllers/downloaders_controller.rb
@@ -16,7 +16,7 @@ class DownloadersController < Admin::AdminController
     file_path = DiscourseDownloadFromDrive::DriveDownloader.new(file_id).download
     download_url = "#{url_for(controller: 'downloaders', action: 'show')}?token=#{token}"
     Jobs.enqueue(:send_download_drive_link, to_address: current_user.email, drive_url: download_url)
-    render nothing: true
+    head :ok
   end
 
   def show
@@ -33,7 +33,7 @@ class DownloadersController < Admin::AdminController
       if @error
         render layout: 'no_ember', status: 422, text: "this link has already been used and is therefore expired"
       else
-        render nothing: true, status: 404
+        head 404
       end
     end
   end

--- a/lib/drive_downloader.rb
+++ b/lib/drive_downloader.rb
@@ -17,9 +17,13 @@ module DiscourseDownloadFromDrive
       @turned_on && @api_key.present? && @file_id.present?
     end
 
-    def google_files
+    def collection
       folder_name = Discourse.current_hostname
-      @google_files ||= session.collection_by_title(folder_name).files
+      @collection ||= session.collection_by_title(folder_name) || session.create_collection(folder_name)
+    end
+
+    def google_files
+      @google_files ||= collection&.files || []
     end
 
     def json_list

--- a/plugin.rb
+++ b/plugin.rb
@@ -17,9 +17,12 @@ gem 'declarative-option', '0.1.0', { require: false }
 gem 'declarative', '0.0.9', { require: false }
 gem 'uber', '0.1.0', { require: false }
 gem 'representable', "3.0.4", { require: false }
-gem 'google-api-client', "0.10.3", { require: false }
+gem 'mime-types-data', "3.2016.0521", {require: false}
+gem 'mime-types', "3.1", {require: false}
+gem 'retriable', "3.0.2", {require: false}
+gem 'google-api-client', "0.11.3", { require: false }
 
-gem 'google_drive', '2.1.2'
+gem 'google_drive', '2.1.11'
 require 'sidekiq'
 
 enabled_site_setting :discourse_sync_to_googledrive_enabled

--- a/spec/downloaders_controller_spec.rb
+++ b/spec/downloaders_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require_relative "../app/jobs/regular/send_download_drive_link.rb"
 
 describe DownloadersController, type: :controller do
   before {
@@ -44,27 +45,31 @@ describe DownloadersController, type: :controller do
     end
 
     describe "PUT #create" do
-      let(:sample_file_id) {
-        "0B7WjYjWZJv_4blA0a2p6RzVraFE"
-      }
+      let(:sample_file_id) { "0B7WjYjWZJv_4blA0a2p6RzVraFE" }
+      let(:download_path) { "http://example.com/path/to/download" }
+      let(:job_klass) { Jobs::SendDownloadDriveLink }
 
       before {
+        SiteSetting.queue_jobs = true
         drive_instance = DiscourseDownloadFromDrive::DriveDownloader
         drive_instance.any_instance.stubs(:file_id).returns(sample_file_id)
+        drive_instance.any_instance.stubs(:download).returns(download_path)
       }
 
       it "sends a google-file-id to the job" do
-        put :create, xhr: true, params: { file_id: sample_file_id }
-        @file_id = :sample_file_id
-        expect(@file_id).to eq(:sample_file_id)
-      end
+        expect do
+          put :create,
+              xhr: true,
+              params: { file_id: sample_file_id },
+              format: :json
+          expect(response).to be_success
+          expect(response).to have_http_status(200)
+        end.to change { job_klass.jobs.count }.by(1)
 
-      it "responds with 200 status" do
-        put :create, xhr: true, params: { file_id: sample_file_id }
-        expect(response).to be_success
-        expect(response).to have_http_status(200)
+        job_args = job_klass.jobs.last['args'].first
+        expect(job_args['to_address']).to eq(@admin.email)
+        expect(job_args['drive_url']).to include("/admin/plugins/discourse-sync-to-googledrive/downloader/")
       end
-
     end
   end
 end

--- a/spec/downloaders_controller_spec.rb
+++ b/spec/downloaders_controller_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
-describe Admin::AdminController::DownloadersController, type: :controller do
+describe DownloadersController, type: :controller do
+  before {
+    SiteSetting.discourse_sync_to_googledrive_enabled = true
+  }
 
   context "while logged in as an admin" do
 
@@ -29,22 +32,21 @@ describe Admin::AdminController::DownloadersController, type: :controller do
       }
 
       it "returns a json list of all google_drive files" do
-        xhr :get, :index, format: :json
+        get :index, format: :json, xhr: true
         expect(response.body).to eq(sample_json)
       end
 
       it "responds with 200 status" do
-        xhr :get, :index
+        get :index, xhr: true
         expect(response).to be_success
         expect(response).to have_http_status(200)
       end
     end
 
-    describe "POST #create" do
+    describe "PUT #create" do
       let(:sample_file_id) {
         "0B7WjYjWZJv_4blA0a2p6RzVraFE"
       }
-
 
       before {
         drive_instance = DiscourseDownloadFromDrive::DriveDownloader
@@ -52,13 +54,13 @@ describe Admin::AdminController::DownloadersController, type: :controller do
       }
 
       it "sends a google-file-id to the job" do
-        xhr :post, :create
+        put :create, xhr: true, params: { file_id: sample_file_id }
         @file_id = :sample_file_id
         expect(@file_id).to eq(:sample_file_id)
       end
 
       it "responds with 200 status" do
-        xhr :post, :create
+        put :create, xhr: true, params: { file_id: sample_file_id }
         expect(response).to be_success
         expect(response).to have_http_status(200)
       end


### PR DESCRIPTION
Enable this plugin before the spec runs.

I have no idea how to let the `PUT #create` part of spec file `downloaders_controller_spec.rb` pass unit test.